### PR TITLE
to compile the exynos5420 kernel for v2awifi, v2awifi needs the same definitions as v1awifi. without, compile fails

### DIFF
--- a/drivers/usb/gadget/composite.c
+++ b/drivers/usb/gadget/composite.c
@@ -1538,7 +1538,7 @@ static u8 override_id(struct usb_composite_dev *cdev, u8 *desc)
 	return *desc;
 }
 
-#ifdef CONFIG_V1A
+#if defined(CONFIG_V1A) || defined(CONFIG_V2A)
 static void composite_redriver_work(struct work_struct *data)
 {
 	struct usb_composite_dev	*cdev =  container_of(data, struct usb_composite_dev, redriver_work);
@@ -1658,7 +1658,7 @@ static int composite_bind(struct usb_gadget *gadget)
 		goto fail;
 
 	INFO(cdev, "%s ready\n", composite->name);
-#ifdef CONFIG_V1A
+#if defined(CONFIG_V1A) || defined(CONFIG_V2A)
 	INIT_WORK(&cdev->redriver_work, composite_redriver_work);
 #endif
 	return 0;

--- a/drivers/usb/gadget/exynos_ss_udc.c
+++ b/drivers/usb/gadget/exynos_ss_udc.c
@@ -2548,7 +2548,7 @@ static void exynos_ss_udc_irq_connectdone(struct exynos_ss_udc *udc)
 	}
 #endif
 #endif
-#ifdef CONFIG_V1A
+#if defined(CONFIG_V1A) || defined(CONFIG_V2A)
 			udc->speed_limit = udc->gadget.speed;
 			printk(KERN_ERR"usb: Update the speed limit value %d \n",udc->speed_limit);
 #endif

--- a/include/linux/usb/composite.h
+++ b/include/linux/usb/composite.h
@@ -405,7 +405,7 @@ struct usb_composite_dev {
 	 */
 	bool				mute_switch;
 	bool				force_disconnect;
-#ifdef CONFIG_V1A
+#if defined(CONFIG_V1A) || defined(CONFIG_V2A)
 	struct work_struct redriver_work;
 #endif
 #endif


### PR DESCRIPTION
To compile the exynos5420 kernel for v2awifi, v2awifi needs the same definitions as v1awifi. 
Without these, the kernel compile fails.
With these changes, the kernel compiles and also LineageOS 17.1 (and /e/OS-1.?-q) runs successful.